### PR TITLE
Make two or more API versions work

### DIFF
--- a/src/APIResourceManager.php
+++ b/src/APIResourceManager.php
@@ -57,14 +57,15 @@ class APIResourceManager
      */
     public function getRouteName($route)
     {
-        if (!$this->routePath) {
+        // if (!$this->routePath) {
             // Grab route_prefix config first. If it's not set,
             // grab the resources, and replace `\` with `.`, and
             // transform it all to lowercase.
-            $this->routePath = $this->getConfig('route_prefix')
-                ?: str_replace('\\', '.', strtolower($this->getConfig('resources')));
-        }
-        return "{$this->routePath}.v{$this->current}" . str_after($route, $this->routePath);
+            $name = preg_replace('/^([a-z]+)\..*/', '$1', $route);
+            $this->routePath = $this->getConfig('route_prefix', $name)
+                ?: str_replace('\\', '.', strtolower($this->getConfig('resources', $name)));
+        // }
+        return "{$this->routePath}.v{$this->getConfig('version', $name)}" . str_after($route, $this->routePath);
     }
 
     /**


### PR DESCRIPTION
So, I followed the README and turns out `api_route()` can't distinguish between 2 or more APIs...
The code only works for one of the many, more precisely the one defined in `config('api.default')`.

This is not a perfect solution to the problem of using arrays instead of strings in `config/api.php`, but at least now both APIs get their routes as intended...

For comparison, here is my api.php file:
```php
<?php

return [
    'default' => 'api',
    'version' => [
        'api' => '2',
        'desktop' => '3',
    ],
    'resources_path' => [
        'api' => 'App\Http\Resources',
        'desktop' => 'App\Http\Resources',
    ],
    'resources' => [
        'api' => 'Api',
        'desktop' => 'Desktop',
    ],
    'route_prefix' => [
        'api' => 'api',
        'desktop' => 'desktop',
    ],
];
```

And after applying the modifications to `getRouteName` both commands bellow work as expected:
```php
<?php

 # Interprets 'api.some.name' as 'route('api.v2.some.name')'
api_route('api.some.name');
 # Interprets 'desktop.another.name' as 'route('desktop.v3.another.name')'
api_route('desktop.another.name');
```