### PR TITLE
Added Illuminate 10 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,8 @@
     ],
     "require": {
       "php" : "^7.4|^8.0|^8.1|^8.2",
-      "illuminate/support": "^7.0|^8.0|^9.0",
-      "illuminate/http": "^7.0|^8.0|^9.0"
+      "illuminate/support": "^7.0|^8.0|^9.0|^10.0",
+      "illuminate/http": "^7.0|^8.0|^9.0|^10.0"
     },
     "require-dev": {
       "orchestra/testbench": "^5.0|^6.0|^7.0",


### PR DESCRIPTION
This pull request adds support to Illuminate 10 in both Illuminate packages used, which translates to Laravel 10 support.

All tests passed even after the upgrade.

Following the [official Laravel recommendations](https://laravel.com/docs/10.x/upgrade#miscellaneous), I also manually checked both the Support and Http packges of Illuminate, using the GitHub comparison tool, to check for any possible breaking changes between 9.x and 10.x that could be a problem for this library. I couldn't find any.